### PR TITLE
Updated to work with latest Pocketbase

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
 		"sade": "^1.8.1"
 	},
 	"devDependencies": {
-		"@types/node": "^18.13.0",
-		"@changesets/cli": "^2.26.1",
-		"pocketbase": "^0.15.2",
-		"typescript": "^5.1.3",
-		"tsup": "^7.1.0",
-		"prettier": "^2.8.8"
+		"@types/node": "^20.8.4",
+		"@changesets/cli": "^2.26.2",
+		"pocketbase": "^0.18.2",
+		"typescript": "^5.2.2",
+		"tsup": "^7.2.0",
+		"prettier": "^3.0.3"
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Record as PocketBaseRecord } from 'pocketbase';
+import { RecordModel as PocketBaseRecord } from 'pocketbase';
 
 export type Simplify<T> = T extends infer o ? { [K in keyof o]: o[K] } : never;
 export type ArrayInnerType<T> = T extends Array<infer V> ? V : T;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"esm": true
 	},
 	"compilerOptions": {
-		"module": "ESNext",
+		"module": "NodeNext",
 		"target": "ESNext",
 		"moduleResolution": "NodeNext",
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
As defined in pocketbase changelog
- Record has been changed to **RecordModel**
- Updated Packages
- Updated module to from **ESNext** to **NodeNext**