### PR TITLE
fix: make metro bundler resolve work

### DIFF
--- a/.changeset/healthy-moons-peel.md
+++ b/.changeset/healthy-moons-peel.md
@@ -1,0 +1,5 @@
+---
+"typed-pocketbase": patch
+---
+
+Add main field to package.json

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"src"
 	],
 	"type": "module",
+	"main": "./dist/client/index.js",
 	"module": "./dist/client/index.js",
 	"types": "./dist/client/index.d.ts",
 	"bin": {


### PR DESCRIPTION
When trying to use this package with a expo/react-native project, the metro bundler looks for the main field in the package.json
![Screenshot_2024-03-27_at_5 25 26_PM](https://github.com/david-plugge/typed-pocketbase/assets/84459/8ada3d76-f2d5-48aa-80b3-ad75b264d51e)
