### PR TITLE
switch to _via_ expand syntax

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -300,7 +300,7 @@ function buildCollectionDefinitions(collections: Collection[]) {
 					);
 
 					target.relations.push({
-						name: `${collection.name}(${field.name})`,
+						name: `${collection.name}_via_${field.name}`,
 						target: from,
 						unique: isUnique
 					});


### PR DESCRIPTION
PR to switch to the new expand format  to remove the deprecation warnings
2024/10/07 18:23:35 Server started at http://127.0.0.1:8090
├─ REST API: http://127.0.0.1:8090/api/
└─ Admin UI: http://127.0.0.1:8090/_/
2024/10/07 21:13:50 comments(post) expand format is deprecated and will be removed in the future. Consider replacing it with comments_via_post.
